### PR TITLE
Remove unused drivetrain m_leftPid, m_rightPid, and m_feedForward 

### DIFF
--- a/Comp2022/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/Comp2022/src/main/cpp/subsystems/Drivetrain.cpp
@@ -72,10 +72,7 @@ Drivetrain::Drivetrain()
     m_turnPid = frc2::PIDController(m_turnPidKp, m_turnPidKi, m_turnPidKd);
     m_throttlePid = frc2::PIDController(m_throttlePidKp, m_throttlePidKi, m_throttlePidKd);
 
-    // Ramsete Pid Controllers
-    m_leftPid = frc2::PIDController(m_ramsetePidKp, m_ramsetePidKi, m_ramsetePidKd);
-    m_rightPid = frc2::PIDController(m_ramsetePidKp, m_ramsetePidKi, m_ramsetePidKd);
-
+    // Ramsete Controller
     m_ramseteController = frc::RamseteController(m_ramseteB, m_ramseteZeta);
 
     Initialize();
@@ -732,14 +729,7 @@ void Drivetrain::RamseteFollowerInit(string pathName, bool resetOdometry)
 
     m_ramseteB = frc::SmartDashboard::GetNumber("DTR_ramseteB", m_ramseteB);
     m_ramseteZeta = frc::SmartDashboard::GetNumber("DTR_ramseteZeta", m_ramseteZeta);
-
-    // m_leftPid = frc2::PIDController{ m_ramsetePidKp, m_ramsetePidKi, m_ramsetePidKd };
-    // m_rightPid = frc2::PIDController{ m_ramsetePidKp, m_ramsetePidKi, m_ramsetePidKd };
     m_ramseteController = frc::RamseteController{ m_ramseteB, m_ramseteZeta };
-
-    // TODO: Not sure if this is really needed or used
-    m_leftPid.SetTolerance(m_tolerance);
-    m_rightPid.SetTolerance(m_tolerance);
 
     // Get our trajectory
     // TODO: Move this to be able to load a trajectory while disabled when

--- a/Comp2022/src/main/include/subsystems/Drivetrain.h
+++ b/Comp2022/src/main/include/subsystems/Drivetrain.h
@@ -17,8 +17,6 @@
 #include <frc/XboxController.h>
 #include <frc/controller/PIDController.h>
 #include <frc/controller/RamseteController.h>
-#include <frc/controller/SimpleMotorFeedforward.h>
-#include <frc/kinematics/DifferentialDriveKinematics.h>
 #include <frc/kinematics/DifferentialDriveOdometry.h>
 #include <frc/simulation/DifferentialDrivetrainSim.h>
 #include <frc/smartdashboard/Field2d.h>
@@ -164,10 +162,7 @@ private:
     // Ramsete follower objects
     frc::Trajectory m_trajectory;
     frc::RamseteController m_ramseteController;
-    frc::SimpleMotorFeedforward<meter> m_feedforward{ DriveConstants::ks, DriveConstants::kv, DriveConstants::ka };
     frc::DifferentialDriveKinematics m_kinematics{ DriveConstants::kTrackWidthMeters };
-    frc2::PIDController m_leftPid{ 0.0, 0.0, 0.0 };
-    frc2::PIDController m_rightPid{ 0.0, 0.0, 0.0 };
     frc::Timer m_trajTimer;
 
     // Path following variables


### PR DESCRIPTION
These references that were used when Ramsete was voltage controlled -- which no longer exists.