### PR TITLE
Modified logging info to remove a CAN transaction and reduce log size

### DIFF
--- a/Comp2022/src/main/cpp/subsystems/Climber.cpp
+++ b/Comp2022/src/main/cpp/subsystems/Climber.cpp
@@ -38,7 +38,7 @@ Climber::Climber()
     // Validate Talon SRX controllers, initialize and display firmware versions
     m_talonValidCL14 = frc2135::TalonUtils::TalonCheck(m_motorCL14, "CL", "CL14");
     m_talonValidCL15 = frc2135::TalonUtils::TalonCheck(m_motorCL15, "CL", "CL15");
-    
+
     frc::SmartDashboard::PutBoolean("CL_CL14Valid", m_talonValidCL14);
     frc::SmartDashboard::PutBoolean("CL_CL15Valid", m_talonValidCL15);
 
@@ -100,12 +100,18 @@ Climber::Climber()
         m_motorCL14.SetNeutralMode(NeutralMode::Brake);
         m_motorCL14.SetSafetyEnabled(false);
 
+        m_motorCL14.ConfigVoltageCompSaturation(12.0, 0);
+        m_motorCL14.EnableVoltageCompensation(true);
+
         frc2135::TalonUtils::CheckError(
             m_motorCL14.ConfigSupplyCurrentLimit(m_supplyCurrentLimits),
             "CL14 ConfigSupplyCurrentLimits");
         frc2135::TalonUtils::CheckError(
             m_motorCL14.ConfigStatorCurrentLimit(m_statorCurrentLimits),
             "CL14 ConfigStatorCurrentLimits");
+
+        // Configure Magic Motion settings
+        frc2135::TalonUtils::CheckError(m_motorCL14.SelectProfileSlot(0, 0), "CL14 SelectProfileSlot");
 
         // Configure sensor settings
         frc2135::TalonUtils::CheckError(
@@ -116,18 +122,6 @@ Climber::Climber()
         frc2135::TalonUtils::CheckError(
             m_motorCL14.ConfigAllowableClosedloopError(0, m_CLAllowedError, kCANTimeout),
             "CL14 ConfigAllowableClosedloopError");
-
-        // Set soft limits for climber height
-        //m_motorCL14.ConfigForwardSoftLimitThreshold(InchesToCounts(m_climberMaxHeight), kCANTimeout);
-        //m_motorCL14.ConfigReverseSoftLimitThreshold(InchesToCounts(m_climberMinHeight), kCANTimeout);
-        // m_motorCL14.ConfigForwardSoftLimitEnable(true, kCANTimeout);
-        // m_motorCL14.ConfigReverseSoftLimitEnable(true, kCANTimeout);
-
-        m_motorCL14.ConfigVoltageCompSaturation(12.0, 0);
-        m_motorCL14.EnableVoltageCompensation(true);
-
-        // Configure Magic Motion settings
-        frc2135::TalonUtils::CheckError(m_motorCL14.SelectProfileSlot(0, 0), "CL14 SelectProfileSlot");
 
         frc2135::TalonUtils::CheckError(
             m_motorCL14.ConfigMotionCruiseVelocity(m_velocity, kCANTimeout),
@@ -151,7 +145,7 @@ Climber::Climber()
     {
         m_motorCL15.SetInverted(false);
         m_motorCL15.SetNeutralMode(NeutralMode::Brake);
-        m_motorCL14.SetSafetyEnabled(false);
+        m_motorCL15.SetSafetyEnabled(false);
 
         m_motorCL15.ConfigVoltageCompSaturation(12.0, 0);
         m_motorCL15.EnableVoltageCompensation(true);
@@ -165,6 +159,16 @@ Climber::Climber()
 
         // Configure Magic Motion settings
         frc2135::TalonUtils::CheckError(m_motorCL15.SelectProfileSlot(0, 0), "CL15 SelectProfileSlot");
+
+        // Configure sensor settings
+        frc2135::TalonUtils::CheckError(
+            m_motorCL15.SetSelectedSensorPosition(0, 0, kCANTimeout),
+            "CL15 SetSelectedSensorPosition");
+
+        // Set allowable closed loop error
+        frc2135::TalonUtils::CheckError(
+            m_motorCL15.ConfigAllowableClosedloopError(0, m_CLAllowedError, kCANTimeout),
+            "CL15 ConfigAllowableClosedloopError");
 
         frc2135::TalonUtils::CheckError(
             m_motorCL15.ConfigMotionCruiseVelocity(m_velocity, kCANTimeout),
@@ -394,13 +398,13 @@ void Climber::MoveToCalibrate(void)
 void Climber::Calibrate()
 {
     if (m_talonValidCL14)
-    {
         m_motorCL14.SetSelectedSensorPosition(0, 0, kCANTimeout);
-        m_targetInches = 0;
-        m_curInches = 0;
-    }
+
     if (m_talonValidCL15)
         m_motorCL15.SetSelectedSensorPosition(0, 0, kCANTimeout);
+
+    m_targetInches = 0;
+    m_curInches = 0;
     m_calibrated = true;
     frc::SmartDashboard::PutBoolean("CL_Calibrated", m_calibrated);
 }

--- a/Comp2022/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/Comp2022/src/main/cpp/subsystems/Drivetrain.cpp
@@ -427,9 +427,19 @@ int Drivetrain::MetersToNativeUnits(units::meter_t position)
     return position / DriveConstants::kEncoderMetersPerCount;
 }
 
+units::meter_t Drivetrain::NativeUnitsToMeters(int nativeUnits)
+{
+    return nativeUnits * DriveConstants::kEncoderMetersPerCount;
+}
+
 int Drivetrain::MPSToNativeUnits(units::meters_per_second_t velocity)
 {
     return (velocity / DriveConstants::kEncoderMetersPerCount / 10).to<double>();
+}
+
+units::meters_per_second_t Drivetrain::NativeUnitsToMPS(int nativeUnitsVelocity)
+{
+    return nativeUnitsVelocity * DriveConstants::kEncoderMetersPerCount * 10 / 1_s;
 }
 
 double Drivetrain::JoystickOutputToNative(double output)
@@ -800,22 +810,20 @@ bool Drivetrain::LimelightSanityCheck(double horizAngleRange, double distRange)
     bool tv = robotContainer->m_vision.GetTargetValid();
     m_limelightDistance = robotContainer->m_vision.CalculateDist();
 
+    bool sanityCheck =
+        tv && (fabs(tx) <= horizAngleRange) && (fabs(m_setPointDistance - m_limelightDistance) <= distRange);
+    // && (fabs(ty) <= vertAngleRange)
+
     spdlog::info(
-        "DTL tv {} tx {:.1f} ty{:.1f} distError {:.1f} lldistance {:.1f}",
+        "DTL tv {} tx {:.1f} ty {:.1f} lldistance {:.1f} distError {:.1f} sanity check {}",
         tv,
         tx,
         ty,
+        m_limelightDistance,
         fabs(m_setPointDistance - m_limelightDistance),
-        m_limelightDistance);
+        (sanityCheck) ? "PASSED" : "FAILED");
 
-    if (tv && (fabs(tx) <= horizAngleRange) && (fabs(m_setPointDistance - m_limelightDistance) <= distRange))
-    {
-        spdlog::info("Limelight Sanity Check passed");
-        return true;
-    }
-    spdlog::info("Limelight Sanity Check failed");
-    return false;
-    // && (fabs(ty) <= vertAngleRange)
+    return sanityCheck;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -837,14 +845,17 @@ void Drivetrain::RamseteFollowerInit(frc::Trajectory trajectory, bool resetOdome
     m_trajTimer.Reset();
     m_trajTimer.Start();
 
-    spdlog::info("DTR Size of state table is {}", trajectoryStates.size());
+    spdlog::info(
+        "DTR Size of state table is {} and takes {:.3f} secs",
+        trajectoryStates.size(),
+        m_trajectory.TotalTime().to<double>());
 
     for (unsigned int i = 0; i < trajectoryStates.size(); i++)
     {
         frc::Trajectory::State curState = trajectoryStates[i];
         if (m_ramseteDebug >= 1)
             spdlog::info(
-                "DTR state time {} Velocity {} Accleration {} Rotation {}",
+                "DTR state time {:.3f} Vel {:.2f} Accel {:.2f} Rotation {:.0f}",
                 curState.t,
                 curState.velocity,
                 curState.acceleration,
@@ -869,8 +880,8 @@ void Drivetrain::RamseteFollowerExecute(void)
 
     double velLeftTarget = MPSToNativeUnits(targetSpeed.left);
     double velRightTarget = MPSToNativeUnits(targetSpeed.right);
-    double velLeftCurrent = m_motorL1.GetSelectedSensorVelocity();
-    double velRightCurrent = m_motorR3.GetSelectedSensorVelocity();
+    double velLeftCurrent = MPSToNativeUnits(m_wheelSpeeds.left);
+    double velRightCurrent = MPSToNativeUnits(m_wheelSpeeds.right);
 
     double xTrajTarget = trajState.pose.X().to<double>();
     double yTrajTarget = trajState.pose.Y().to<double>();
@@ -916,7 +927,8 @@ void Drivetrain::RamseteFollowerExecute(void)
     m_diffDrive.FeedWatchdog();
     if (m_ramseteDebug >= 1)
         spdlog::info(
-            "DTR cur XYR {:.2f} {:.2f} {:.1f} | targ XYR {:.2f} {:.2f} {:.1f} | chas XYO {:.2f} {:.2f} {:.1f} | targ vel LR {:.2f} {:.2f} | cur vel LR {:.2f} {:.2f}",
+            "DTR tim {:.2f} curXYR {:.2f} {:.2f} {:.0f} | targXYR {:.2f} {:.2f} {:.0f} | chasXYO {:.2f} {:.2f} {:.0f} | targVelLR {:.2f} {:.2f} | curVelLR {:.2f} {:.2f}",
+            m_trajTimer.Get().to<double>(),
             xTrajCurrent,
             yTrajCurrent,
             headingCurrent,
@@ -926,24 +938,16 @@ void Drivetrain::RamseteFollowerExecute(void)
             targetChassisSpeeds.vx.to<double>(),
             targetChassisSpeeds.vy.to<double>(),
             targetChassisSpeeds.omega.to<double>(),
-            velLeftTarget,
-            velRightTarget,
-            velLeftCurrent,
-            velRightCurrent);
+            targetSpeed.left.to<double>(),
+            targetSpeed.right.to<double>(),
+            NativeUnitsToMPS(velLeftCurrent).to<double>(),
+            NativeUnitsToMPS(velRightCurrent).to<double>());
 }
 
 bool Drivetrain::RamseteFollowerIsFinished(void)
 {
     if (m_trajTimer.Get() == 0_s)
         return false;
-
-    if (m_ramseteDebug >= 1)
-        spdlog::info(
-            "time targTime {:.2f} {:.2f} | cur vel LR {:.2f} {:.2f}",
-            m_trajTimer.Get().to<double>(),
-            m_trajectory.TotalTime().to<double>(),
-            m_wheelSpeeds.left.to<double>(),
-            m_wheelSpeeds.right.to<double>());
 
     return (
         (m_trajTimer.Get() >= m_trajectory.TotalTime()) && (abs(m_wheelSpeeds.left.to<double>()) <= 0 + m_tolerance)

--- a/Comp2022/src/main/cpp/subsystems/Shooter.cpp
+++ b/Comp2022/src/main/cpp/subsystems/Shooter.cpp
@@ -198,7 +198,7 @@ bool Shooter::IsAtDesiredRPM()
     }
 
     if ((m_state != SHOOTERSPEED_STOP) and !atDesiredSpeed)
-        spdlog::info("SH m_flywheelCurrentRPM {:.1f}", m_flywheelCurrentRPM);
+        spdlog::info("SH m_flywheelCurrentRPM {:.0f}", m_flywheelCurrentRPM);
 
     if (atDesiredSpeed != previousAtDesiredSpeed)
     {

--- a/Comp2022/src/main/include/subsystems/Drivetrain.h
+++ b/Comp2022/src/main/include/subsystems/Drivetrain.h
@@ -192,7 +192,9 @@ private:
     frc::DifferentialDriveWheelSpeeds GetWheelSpeedsMPS(void);
 
     int MetersToNativeUnits(units::meter_t position);
+    units::meter_t NativeUnitsToMeters(int nativeUnits);
     int MPSToNativeUnits(units::meters_per_second_t velocity);
+    units::meters_per_second_t NativeUnitsToMPS(int nativeUnitsVelocity);
 
     double JoystickOutputToNative(double rpm);
 


### PR DESCRIPTION
Modified logging info to remove an extra CAN access and reduce the logged data. Please confirm that no logic has changed, and only the logged info is different. Also added encoder reset in climber for CL15, since it is used by Motion Magic.