### PR TITLE
Made some methods accessible in Vision.java and ported methods into Drivetrain.java

### DIFF
--- a/Offseason2022/src/main/java/frc/robot/commands/DriveTeleop.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/DriveTeleop.java
@@ -4,6 +4,7 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.RobotContainer;
 import frc.robot.subsystems.Drivetrain;
 
 /**
@@ -22,17 +23,23 @@ public class DriveTeleop extends CommandBase
   // Called when the command is initially scheduled.
   @Override
   public void initialize( )
-  {}
+  {
+    m_drivetrain.moveWithJoysticksInit( );
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute( )
-  {}
+  {
+    m_drivetrain.moveWithJoysticks(RobotContainer.getInstance( ).getDriver( ));
+  }
 
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted)
-  {}
+  {
+    m_drivetrain.moveWithJoysticksEnd( );
+  }
 
   // Returns true when the command should end.
   @Override

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -3,6 +3,8 @@
 
 package frc.robot.subsystems;
 
+import javax.xml.crypto.Data;
+
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.InvertType;
@@ -19,8 +21,10 @@ import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
+import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
+import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.RobotState;
@@ -31,6 +35,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.RobotContainer;
 import frc.robot.frc2135.PhoenixUtil;
 import frc.robot.frc2135.RobotConfig;
 
@@ -68,7 +73,7 @@ public class Drivetrain extends SubsystemBase
   private final int                       kPidIndex             = 0;        // PID index for primary sensor
   private final int                       kCANTimeout           = 30;     // CAN timeout in msec to wait for response
 
-  // TODO: adjust kV and kA angular from robot characterization
+  // TODO: Adjust kV and kA angular from robot characterization
   private DifferentialDrivetrainSim       m_driveSim            = new DifferentialDrivetrainSim(
       LinearSystemId.identifyDrivetrainSystem(
           Constants.Drivetrain.kv,
@@ -121,6 +126,8 @@ public class Drivetrain extends SubsystemBase
   private int                             m_resetCountR3; // motor reset count storer
   private int                             m_resetCountR4; // motor reset count storer
 
+  private int                             m_periodicInterval    = 0;
+
   // limelight drive
   private double                          m_turnConstant        = 0;
   private double                          m_turnPidKp           = 0.1;
@@ -149,10 +156,17 @@ public class Drivetrain extends SubsystemBase
   private boolean                         m_ramseteTuningMode;
 
   // Odometry and telemetry
-  private Field2d                         m_field               = new Field2d( );
-
+  private double                          m_distanceLeft;
+  private double                          m_distanceRight;
+  private DifferentialDriveWheelSpeeds    m_wheelSpeeds;
   private DifferentialDriveOdometry       m_odometry            = new DifferentialDriveOdometry(
       Rotation2d.fromDegrees(0.0));
+  private Field2d                         m_field               = new Field2d( );
+
+  public double                           m_currentl1           = 0.0; // Motor L1 output current from Falcon
+  public double                           m_currentL2           = 0.0; // Motor L2 output current from Falcon
+  public double                           m_currentR3           = 0.0; // Motor R3 output current from Falcon
+  public double                           m_currentR4           = 0.0; // Motor R4 output current from Falcon
 
   /**
    *
@@ -170,7 +184,6 @@ public class Drivetrain extends SubsystemBase
 
     // Validate Talon controllers, reset and display firmware versions
 
-    // TODO: define globaly since the declaration is global already
     m_talonValidL1 = PhoenixUtil.getInstance( ).talonFXInitialize(m_driveL1, "L1");
     m_talonValidL2 = PhoenixUtil.getInstance( ).talonFXInitialize(m_driveL2, "L2");
     m_talonValidR3 = PhoenixUtil.getInstance( ).talonFXInitialize(m_driveR3, "R3");
@@ -211,7 +224,7 @@ public class Drivetrain extends SubsystemBase
     // This method will be called once per scheduler run
     updateOdometry( );
     updateDashboardValues( );
-    // TODO: replace getRobotPose --> C++ version is not inbuilt but a method in file
+
     m_field.setRobotPose(m_field.getRobotPose( ));
 
     m_resetCountL1 += (m_driveL1.hasResetOccurred( ) ? 1 : 0);
@@ -407,12 +420,60 @@ public class Drivetrain extends SubsystemBase
 
   public void updateOdometry( )
   {
+    m_distanceLeft = getDistanceMetersLeft( );
+    m_distanceRight = getDistanceMetersRight( );
+    m_wheelSpeeds = getWheelSpeedsMPS( );
+    m_odometry.update(Rotation2d.fromDegrees(getHeadingAngle( )), m_distanceLeft, m_distanceRight);
 
+    // TODO: Should we convert m_driveDebug to a bool?
+    if (m_driveDebug != 0)
+    {
+      if (m_talonValidL1)
+        // TODO: should we replace this to getStatorCurrent()?
+        m_currentl1 = m_driveL1.getOutputCurrent( );
+      if (m_talonValidL2)
+        m_currentL2 = m_driveL2.getOutputCurrent( );
+      if (m_talonValidR3)
+        m_currentR3 = m_driveR3.getOutputCurrent( );
+      if (m_talonValidR4)
+        m_currentR4 = m_driveR4.getOutputCurrent( );
+    }
   }
 
   public void updateDashboardValues( )
   {
+    // TODO: replace this
+    // SmartDashboard.putNumber("DT_distanceLeft", m_distanceLeft.to<double>());
+    // SmartDashboard.putNumber("DT_distanceRight", m_distanceRight.to<double>());
+    // SmartDashboard.putNumber("DT_wheelSpeedLeft", m_wheelSpeeds.left.to<double>());
+    // SmartDashboard.putNumber("DT_wheelSpeedRight", m_wheelSpeeds.right.to<double>());
+    // SmartDashboard.putNumber("DT_getHeadingAngle", GetHeadingAngle().to<double>());
+    // SmartDashboard.putNumber("DT_heading", getPose().Rotation().Degrees().to<double>());
+    // SmartDashboard.putNumber("DT_currentX", getPose().x().to<double>());
+    // SmartDashboard.putNumber("DT_currentY", getPose().y().to<double>());
 
+    SmartDashboard.putNumber("DT_Current_L1", m_currentl1);
+    SmartDashboard.putNumber("DT_Current_L2", m_currentL2);
+    SmartDashboard.putNumber("DT_Current_R3", m_currentR3);
+    SmartDashboard.putNumber("DT_Current_R4", m_currentR4);
+
+    SmartDashboard.putNumber("HL_Resets_L1", m_resetCountL1);
+    SmartDashboard.putNumber("HL_Resets_L2", m_resetCountL2);
+    SmartDashboard.putNumber("HL_Resets_R3", m_resetCountR3);
+    SmartDashboard.putNumber("HL_Resets_R4", m_resetCountR4);
+
+    // Only update indicators every 100 ms to cut down on network traffic
+    if ((m_periodicInterval++ % 5 == 0) && (m_driveDebug > 1))
+    {
+      // TODO: How to implement "GetPose().Rotation().Degrees()" and round?
+
+      DataLogManager.log(getSubsystem( ) + ": DT deg " + Rotation2d.fromDegrees(getHeadingAngle( )) + "LR dist"
+      m_distanceLeft +" "+  m_distanceRight) + " amps (" + String.format("%.1f", m_currentl1) + " " +
+    String.format("%.1f", m_currentL2) + " " +
+      String.format("%.1f", m_currentR3) + " " +
+      String.format("%.1f", m_currentR4) + ")");
+
+    }
   }
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -446,23 +507,21 @@ public class Drivetrain extends SubsystemBase
     return 0;
   }
 
-  // public DifferentialDriveWheelSpeeds getWheelSpeedsMPS( )
-  // {
-  // double leftVelocity = 0;
-  // double rightVelocity = 0;
+  public DifferentialDriveWheelSpeeds getWheelSpeedsMPS( )
+  {
+    double leftVelocity = 0;
+    double rightVelocity = 0;
 
-  // if (m_talonValidL1)
-  // leftVelocity = Constants.Drivetrain.kEncoderMetersPerCount * m_driveL1.getSelectedSensorVelocity( ) * 10;
+    if (m_talonValidL1)
+      leftVelocity = Constants.Drivetrain.kEncoderMetersPerCount * m_driveL1.getSelectedSensorVelocity( ) * 10;
 
-  // if (m_talonValidR3)
-  // {
-  // rightVelocity = Constants.Drivetrain.kEncoderMetersPerCount * m_driveR3.getSelectedSensorVelocity( ) * 10;
-  // }
-  // //TODO: Replace return statement
-  // //return {leftVelocity, rightVelocity};
+    if (m_talonValidR3)
+      rightVelocity = Constants.Drivetrain.kEncoderMetersPerCount * m_driveR3.getSelectedSensorVelocity( ) * 10;
 
-  // }
+    return new DifferentialDriveWheelSpeeds(leftVelocity, rightVelocity);
+  }
 
+  // Helper methods to convert between meters and native units
   public int metersToNativeUnits(double meters)
   {
     return (int) (meters / Constants.Drivetrain.kEncoderMetersPerCount);
@@ -486,21 +545,48 @@ public class Drivetrain extends SubsystemBase
   // public double joystickOutputToNative( )
   // {
   // double outputScaling = 1.0;
-  // TODO: figure out how to define output
+  // //TODO: figure out how to define output
   // return (output * outputScaling * Constants.Drivetrain.kRPM * Constants.Drivetrain.kEncoderCPR) / (60.0 * 10.0);
   // }
+
+  void velocityArcadeDrive(double yOutput, double xOutput)
+  {
+    // TODO: what does std mean?
+    double leftOutput = 0;
+    // = JoystickOutputToNative(std::clamp(yOutput + xOutput, -1.0, 1.0));
+    double rightOutput = 0;
+    // = JoystickOutputToNative(std::clamp(yOutput - xOutput, -1.0, 1.0));
+
+    m_driveL1.set(ControlMode.Velocity, leftOutput);
+    m_driveR3.set(ControlMode.Velocity, rightOutput);
+
+    m_diffDrive.feedWatchdog( );
+  }
 
   //
   // Gyro
   //
   public void resetGyro( )
   {
-
+    if (m_pigeonValid)
+      m_gyroOffset = -m_gyro.getFusedHeading( );
   }
 
   public double getHeadingAngle( )
   {
     return (m_pigeonValid) ? (m_gyroOffset + m_gyro.getFusedHeading( )) : 0;
+  }
+
+  public void getYawPitchRoll( )
+  {
+    m_yaw = m_gyro.getYaw( );
+    m_pitch = m_gyro.getPitch( );
+    m_roll = m_gyro.getRoll( );
+  }
+
+  public Pose2d getPose( )
+  {
+    return m_odometry.getPoseMeters( );
   }
 
   //
@@ -515,6 +601,10 @@ public class Drivetrain extends SubsystemBase
     DataLogManager.log(getSubsystem( ) + ": Heading angle after odometry reset" + getHeadingAngle( ));
   }
 
+  ///////////////////////////////////////////////////////////////////////////////
+  //
+  // Set Talon brake/coast mode
+  //
   public void setBrakeMode(boolean brakeMode)
   {
     m_brakeMode = brakeMode;
@@ -541,15 +631,75 @@ public class Drivetrain extends SubsystemBase
       m_driveR4.setNeutralMode(brakeOutput);
   }
 
+  //
+  // Voltage-based tank drive
+  //
+  public void TankDriveVolts(double left, double right)
+  {
+    m_diffDrive.feedWatchdog( );
+    if (m_talonValidL1)
+      m_driveL1.setVoltage(left);
+    if (m_talonValidR3)
+      m_driveR3.setVoltage(right);
+  }
+
+  void syncTalonPIDFromDashboard( )
+  {
+    m_ramsetePidKf = SmartDashboard.getNumber("DTR_ramsetePidKf", m_ramsetePidKf);
+    m_ramsetePidKp = SmartDashboard.getNumber("DTR_ramsetePidKp", m_ramsetePidKp);
+    m_ramsetePidKi = SmartDashboard.getNumber("DTR_ramsetePidKi", m_ramsetePidKi);
+    m_ramsetePidKd = SmartDashboard.getNumber("DTR_ramsetePidKd", m_ramsetePidKd);
+
+    if (m_talonValidL1)
+    {
+      m_driveL1.config_kF(kSlotIndex, m_ramsetePidKf);
+      m_driveL1.config_kP(kSlotIndex, m_ramsetePidKp);
+      m_driveL1.config_kI(kSlotIndex, m_ramsetePidKi);
+      m_driveL1.config_kD(kSlotIndex, m_ramsetePidKd);
+      m_driveL1.selectProfileSlot(kSlotIndex, kPidIndex);
+    }
+
+    if (m_talonValidR3)
+    {
+      m_driveR3.config_kF(kSlotIndex, m_ramsetePidKf);
+      m_driveR3.config_kP(kSlotIndex, m_ramsetePidKp);
+      m_driveR3.config_kI(kSlotIndex, m_ramsetePidKi);
+      m_driveR3.config_kD(kSlotIndex, m_ramsetePidKd);
+      m_driveR3.selectProfileSlot(kSlotIndex, kPidIndex);
+    }
+  }
+
+  //
+  public boolean moveIsStopped( )
+  {
+    // TODO: resolve left and right errors
+    boolean leftStopped = false;
+    // = m_wheelSpeeds.left<=m_tolerance;
+    boolean rightStopped = false;
+    // = m_wheelSpeeds.right<=m_tolerance;
+
+    return (leftStopped && rightStopped);
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  //
+  // Trajectory management
+  //
+  void plotTrajectory(Trajectory trajectory)
+  {
+
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////// Public Interfaces ///////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////
+  //
+  // Reset all sensors - gyro and encoders
+  //
   public void resetSensors( )
   {
     resetEncoders( );
     resetGyro( );
-  }
-
-  public Pose2d getPose( )
-  {
-    return m_odometry.getPoseMeters( );
   }
 
   //
@@ -560,11 +710,20 @@ public class Drivetrain extends SubsystemBase
     m_isQuickTurn = quickTurn;
   }
 
-  public void moveStop( )
+  public void setDriveSlowMode(boolean driveSlowMode)
   {
-
+    m_isDriveSlowMode = driveSlowMode;
   }
 
+  public void moveStop( )
+  {
+    if (m_talonValidL1 || m_talonValidR3)
+      m_diffDrive.tankDrive(0.0, 0.0, false);
+  }
+
+  //
+  // Joystick movement during Teleop
+  //
   public void moveWithJoysticksInit( )
   {
     setBrakeMode(true);
@@ -615,5 +774,39 @@ public class Drivetrain extends SubsystemBase
     m_driveL1.configOpenloopRamp(0.0);
     m_driveR3.configOpenloopRamp(0.0);
   }
+
+  // Movement during limelight shooting phase
+public void moveWithLimelightInit(boolean m_endAtTarget)
+{
+    // get pid values from dashboard
+
+    m_turnConstant = SmartDashboard.getNumber("DTL_TurnConstant", m_turnConstant);
+    m_turnPidKp = SmartDashboard.getNumber("DTL_TurnPidKp", m_turnPidKp);
+    m_turnPidKi = SmartDashboard.getNumber("DTL_TurnPidKi", m_turnPidKi);
+    m_turnPidKd = SmartDashboard.getNumber("DTL_TurnPidKd", m_turnPidKd);
+
+    m_throttlePidKp = SmartDashboard.getNumber("DTL_ThrottlePidKp", m_throttlePidKp);
+    m_throttlePidKi = SmartDashboard.getNumber("DTL_ThrottlePidKi", m_throttlePidKi);
+    m_throttlePidKd = SmartDashboard.getNumber("DTL_ThrottlePidKd", m_throttlePidKd);
+
+    m_maxTurn = SmartDashboard.getNumber("DTL_MaxTurn", m_maxTurn);
+    m_maxThrottle = SmartDashboard.getNumber("DTL_MaxThrottle", m_maxThrottle);
+    m_targetAngle = SmartDashboard.getNumber("DTL_TargetAngle", m_targetAngle);
+
+    m_angleThreshold = SmartDashboard.getNumber("DTL_AngleThreshold", m_angleThreshold);
+    m_distThreshold = SmartDashboard.getNumber("DTL_DistThreshold", m_distThreshold);
+    m_throttleShape = SmartDashboard.getNumber("DTL_ThrottleShape", m_throttleShape);
+    m_setPointDistance = SmartDashboard.getNumber("DTL_SetPointDistance", m_setPointDistance);
+
+    // load in Pid constants to controller
+    //m_turnPid = frc2::PIDController(m_turnPidKp, m_turnPidKi, m_turnPidKd);
+    //m_throttlePid = frc2::PIDController(m_throttlePidKp, m_throttlePidKi, m_throttlePidKd);
+
+    RobotContainer robotContainer = RobotContainer.getInstance();
+    robotContainer.m_yfilter.reset();
+    robotContainer.m_vfilter.reset();
+
+    robotContainer->m_vision.SyncStateFromDashboard();
+}
 
 }

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -15,6 +15,7 @@ import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.sensors.BasePigeonSimCollection;
 import com.ctre.phoenix.sensors.PigeonIMU;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.RamseteController;
@@ -37,8 +38,8 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.RobotContainer;
 import frc.robot.Constants.LED.LEDColor;
+import frc.robot.RobotContainer;
 import frc.robot.frc2135.PhoenixUtil;
 import frc.robot.frc2135.RobotConfig;
 
@@ -78,23 +79,14 @@ public class Drivetrain extends SubsystemBase
 
   // TODO: from Comp 2022 - adjust kV and kA angular from robot characterization
   private DifferentialDrivetrainSim       m_driveSim            = new DifferentialDrivetrainSim(
-      LinearSystemId.identifyDrivetrainSystem(
-          Constants.Drivetrain.kv,
-          Constants.Drivetrain.ka,
-          Constants.Drivetrain.KvAngular,
-          Constants.Drivetrain.KaAngular,
-          Constants.Drivetrain.kTrackWidthMeters),
-      DCMotor.getFalcon500(2),
-      Constants.Drivetrain.kGearRatio,
-      Constants.Drivetrain.kTrackWidthMeters,
-      Constants.Drivetrain.kWheelDiaMeters / 2,
-      VecBuilder.fill(0.001, 0.001, 0.001, 0.1, 0.1, 0.005, 0.005));
+      LinearSystemId.identifyDrivetrainSystem(Constants.Drivetrain.kv, Constants.Drivetrain.ka, Constants.Drivetrain.KvAngular,
+          Constants.Drivetrain.KaAngular, Constants.Drivetrain.kTrackWidthMeters),
+      DCMotor.getFalcon500(2), Constants.Drivetrain.kGearRatio, Constants.Drivetrain.kTrackWidthMeters,
+      Constants.Drivetrain.kWheelDiaMeters / 2, VecBuilder.fill(0.001, 0.001, 0.001, 0.1, 0.1, 0.005, 0.005));
 
   // Current limit settings
-  private SupplyCurrentLimitConfiguration m_supplyCurrentLimits = new SupplyCurrentLimitConfiguration(true, 45.0, 45.0,
-      0.001);
-  private StatorCurrentLimitConfiguration m_statorCurrentLimits = new StatorCurrentLimitConfiguration(true, 80.0, 80.0,
-      0.001);
+  private SupplyCurrentLimitConfiguration m_supplyCurrentLimits = new SupplyCurrentLimitConfiguration(true, 45.0, 45.0, 0.001);
+  private StatorCurrentLimitConfiguration m_statorCurrentLimits = new StatorCurrentLimitConfiguration(true, 80.0, 80.0, 0.001);
 
   // Joysticks
   private double                          m_driveXScaling;  // Scaling applied to Joystick
@@ -165,16 +157,15 @@ public class Drivetrain extends SubsystemBase
   // Ramsete follower objects
   Trajectory                              m_trajectory;
   RamseteController                       m_ramseteController;
-  DifferentialDriveKinematics             m_kinematics          = new DifferentialDriveKinematics(
-      Constants.Drivetrain.kTrackWidthMeters);
+  DifferentialDriveKinematics             m_kinematics          =
+      new DifferentialDriveKinematics(Constants.Drivetrain.kTrackWidthMeters);
   Timer                                   m_trajTimer;
 
   // Odometry and telemetry
   private double                          m_distanceLeft;
   private double                          m_distanceRight;
   private DifferentialDriveWheelSpeeds    m_wheelSpeeds;
-  private DifferentialDriveOdometry       m_odometry            = new DifferentialDriveOdometry(
-      Rotation2d.fromDegrees(0.0));
+  private DifferentialDriveOdometry       m_odometry            = new DifferentialDriveOdometry(Rotation2d.fromDegrees(0.0));
   private Field2d                         m_field               = new Field2d( );
 
   private double                          m_currentl1           = 0.0; // Motor L1 output current from Falcon
@@ -413,16 +404,11 @@ public class Drivetrain extends SubsystemBase
     motor.setSensorPhase(false);
     motor.setSelectedSensorPosition(0, kPidIndex, kCANTimeout);
 
-    PhoenixUtil.getInstance( ).checkError(motor.configOpenloopRamp(m_openLoopRampRate, kCANTimeout),
-        "HL_ConfigOpenloopRamp");
-    PhoenixUtil.getInstance( ).checkError(
-        motor.configClosedloopRamp(m_closedLoopRampRate, kCANTimeout),
+    PhoenixUtil.getInstance( ).checkError(motor.configOpenloopRamp(m_openLoopRampRate, kCANTimeout), "HL_ConfigOpenloopRamp");
+    PhoenixUtil.getInstance( ).checkError(motor.configClosedloopRamp(m_closedLoopRampRate, kCANTimeout),
         "HL_ConfigClosedloopRamp");
-    PhoenixUtil.getInstance( ).checkError(
-        motor.configSupplyCurrentLimit(m_supplyCurrentLimits),
-        "HL_ConfigSupplyCurrentLimit");
-    PhoenixUtil.getInstance( ).checkError(motor.configStatorCurrentLimit(m_statorCurrentLimits),
-        "HL_ConfigStatorCurrentLimit");
+    PhoenixUtil.getInstance( ).checkError(motor.configSupplyCurrentLimit(m_supplyCurrentLimits), "HL_ConfigSupplyCurrentLimit");
+    PhoenixUtil.getInstance( ).checkError(motor.configStatorCurrentLimit(m_statorCurrentLimits), "HL_ConfigStatorCurrentLimit");
   }
 
   public void talonFollowerInitialize(WPI_TalonFX motor, int master)
@@ -430,18 +416,12 @@ public class Drivetrain extends SubsystemBase
     motor.set(ControlMode.Follower, master);
     motor.setInverted(InvertType.FollowMaster);
     motor.setNeutralMode(NeutralMode.Coast);
-    PhoenixUtil.getInstance( ).checkError(
-        motor.setStatusFramePeriod(StatusFrame.Status_1_General, 255, kCANTimeout),
+    PhoenixUtil.getInstance( ).checkError(motor.setStatusFramePeriod(StatusFrame.Status_1_General, 255, kCANTimeout),
         "HL_SetStatusFramePeriod_Status1");
-    PhoenixUtil.getInstance( ).checkError(
-        motor.setStatusFramePeriod(StatusFrame.Status_2_Feedback0, 255, kCANTimeout),
+    PhoenixUtil.getInstance( ).checkError(motor.setStatusFramePeriod(StatusFrame.Status_2_Feedback0, 255, kCANTimeout),
         "HL_SetStatusFramePeriod_Status2");
-    PhoenixUtil.getInstance( ).checkError(
-        motor.configSupplyCurrentLimit(m_supplyCurrentLimits),
-        "HL_ConfigSupplyCurrentLimit");
-    PhoenixUtil.getInstance( ).checkError(
-        motor.configStatorCurrentLimit(m_statorCurrentLimits),
-        "HL_ConfigStatorCurrentLimit");
+    PhoenixUtil.getInstance( ).checkError(motor.configSupplyCurrentLimit(m_supplyCurrentLimits), "HL_ConfigSupplyCurrentLimit");
+    PhoenixUtil.getInstance( ).checkError(motor.configStatorCurrentLimit(m_statorCurrentLimits), "HL_ConfigStatorCurrentLimit");
   }
 
   public void updateOdometry( )
@@ -491,11 +471,9 @@ public class Drivetrain extends SubsystemBase
     // Only update indicators every 100 ms to cut down on network traffic
     if ((m_periodicInterval++ % 5 == 0) && (m_driveDebug > 1))
     {
-      DataLogManager.log(getSubsystem( ) + ": DT deg " + Rotation2d.fromDegrees(getHeadingAngle( )) + "LR dist"
-          + m_distanceLeft + " " + m_distanceRight + " amps (" + String.format("%.1f", m_currentl1) + " " +
-          String.format("%.1f", m_currentL2) + " " +
-          String.format("%.1f", m_currentR3) + " " +
-          String.format("%.1f", m_currentR4) + ")");
+      DataLogManager.log(getSubsystem( ) + ": DT deg " + Rotation2d.fromDegrees(getHeadingAngle( )) + "LR dist" + m_distanceLeft
+          + " " + m_distanceRight + " amps (" + String.format("%.1f", m_currentl1) + " " + String.format("%.1f", m_currentL2)
+          + " " + String.format("%.1f", m_currentR3) + " " + String.format("%.1f", m_currentR4) + ")");
 
     }
   }
@@ -566,20 +544,17 @@ public class Drivetrain extends SubsystemBase
     return nativeUnitsVelocity * Constants.Drivetrain.kEncoderMetersPerCount * 10;
   }
 
-  // public double joystickOutputToNative( )
-  // {
-  // double outputScaling = 1.0;
-  // //TODO: figure out how to define output
-  // return (output * outputScaling * Constants.Drivetrain.kRPM * Constants.Drivetrain.kEncoderCPR) / (60.0 * 10.0);
-  // }
+  public double joystickOutputToNative(double output)
+  {
+    double outputScaling = 1.0;
+    return (output * outputScaling * Constants.Drivetrain.kRPM * Constants.Drivetrain.kEncoderCPR) / (60.0 * 10.0);
+  }
 
   void velocityArcadeDrive(double yOutput, double xOutput)
   {
-    // TODO: what does std mean?
-    double leftOutput = 0;
-    // = JoystickOutputToNative(std::clamp(yOutput + xOutput, -1.0, 1.0));
-    double rightOutput = 0;
-    // = JoystickOutputToNative(std::clamp(yOutput - xOutput, -1.0, 1.0));
+    // define joystickOutputToNative
+    double leftOutput = joystickOutputToNative(MathUtil.clamp(yOutput + xOutput, -1.0, 1.0));
+    double rightOutput = joystickOutputToNative(MathUtil.clamp(yOutput - xOutput, -1.0, 1.0));
 
     m_driveL1.set(ControlMode.Velocity, leftOutput);
     m_driveR3.set(ControlMode.Velocity, rightOutput);
@@ -867,9 +842,8 @@ public class Drivetrain extends SubsystemBase
     SmartDashboard.putNumber("DTL_LimeLightDist", m_limelightDistance);
 
     // cap max turn and throttle output
-    // TODO: figure out what std does
-    // turnOutput = std::clamp(turnOutput, -m_maxTurn, m_maxTurn);
-    // throttleOutput = std::clamp(throttleOutput, -m_maxThrottle, m_maxThrottle);
+    turnOutput = MathUtil.clamp(turnOutput, -m_maxTurn, m_maxTurn);
+    throttleOutput = MathUtil.clamp(throttleOutput, -m_maxThrottle, m_maxThrottle);
 
     // put turn and throttle outputs on the dashboard
     SmartDashboard.putNumber("DTL_TurnOutputClamped", turnOutput);
@@ -879,15 +853,10 @@ public class Drivetrain extends SubsystemBase
       velocityArcadeDrive(throttleOutput, turnOutput);
 
     if (m_limelightDebug >= 1)
-      DataLogManager.log(getSubsystem( ) +
-          ": DTL tv - " + tv +
-          " tx - " + String.format("%.1f", tx) +
-          " ty - " + String.format("%.1f", ty) +
-          " distError" + String.format("%.1f", Math.abs(m_setPointDistance - m_limelightDistance)) +
-          " lldistance" + String.format("%.1f", m_limelightDistance) +
-          " stopped" + moveIsStopped( ) +
-          " tOutput" + String.format("%.2f", turnOutput) +
-          " thrOutput - " + String.format("%.2f", throttleOutput));
+      DataLogManager.log(getSubsystem( ) + ": DTL tv - " + tv + " tx - " + String.format("%.1f", tx) + " ty - "
+          + String.format("%.1f", ty) + " distError" + String.format("%.1f", Math.abs(m_setPointDistance - m_limelightDistance))
+          + " lldistance" + String.format("%.1f", m_limelightDistance) + " stopped" + moveIsStopped( ) + " tOutput"
+          + String.format("%.2f", turnOutput) + " thrOutput - " + String.format("%.2f", throttleOutput));
   }
 
   public boolean moveWithLimelightIsFinished( )
@@ -919,8 +888,7 @@ public class Drivetrain extends SubsystemBase
       robotContainer.m_led.setLLColor(LEDColor.LEDCOLOR_YELLOW);
     }
 
-    return (tv && ((Math.abs(tx)) <= m_angleThreshold)
-        && (Math.abs(m_setPointDistance - m_limelightDistance) <= m_distThreshold)
+    return (tv && ((Math.abs(tx)) <= m_angleThreshold) && (Math.abs(m_setPointDistance - m_limelightDistance) <= m_distThreshold)
         && moveIsStopped( ));
   }
 
@@ -932,4 +900,25 @@ public class Drivetrain extends SubsystemBase
 
     robotContainer.m_led.setLLColor(LEDColor.LEDCOLOR_OFF);
   }
+
+  boolean limelightSanityCheck(double horizAngleRange, double distRange)
+  {
+    // check whether target is valid
+    // check whether the limelight tx and ty is within a certain tolerance
+    // check whether distance is within a certain tolerance
+    RobotContainer robotContainer = RobotContainer.getInstance( );
+    double tx = robotContainer.m_vision.getHorizOffsetDeg( );
+    double ty = robotContainer.m_vision.getVertOffsetDeg( );
+    boolean tv = robotContainer.m_vision.getTargetValid( );
+    m_limelightDistance = robotContainer.m_vision.getDistLimelight( );
+
+    boolean sanityCheck =
+        tv && (Math.abs(tx) <= horizAngleRange) && (Math.abs(m_setPointDistance - m_limelightDistance) <= distRange);
+    // && (fabs(ty) <= vertAngleRange)
+
+    // TODO: DataLog call
+
+    return sanityCheck;
+  }
+
 }

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Vision.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Vision.java
@@ -19,21 +19,21 @@ public class Vision extends SubsystemBase
 {
   private NetworkTable table;
 
-  private double       targetHorizAngle; // Horizontal Offset from Crosshair to Target (-27 to 27 degrees)
-  private double       targetVertAngle;  // Vertical Offset from Crosshair to Target (-20.5 to 20.5 degrees)
-  private double       targetArea;       // Target Area (0% of image to 100% of image)
-  private double       targetSkew;       // Target Skew or rotation (-90 degrees to 0 degrees)
-  private boolean      targetValid;      // Target Valid or not
+  private double       m_targetHorizAngle; // Horizontal Offset from Crosshair to Target (-27 to 27 degrees)
+  private double       m_targetVertAngle;  // Vertical Offset from Crosshair to Target (-20.5 to 20.5 degrees)
+  private double       m_targetArea;       // Target Area (0% of image to 100% of image)
+  private double       m_targetSkew;       // Target Skew or rotation (-90 degrees to 0 degrees)
+  private boolean      m_targetValid;      // Target Valid or not
 
   // Variables in inches to calculate limelight distance
-  private double       distance1   = 48;    // x position in inches for first reference point
-  private double       vertOffset1 = 0.42;  // y reading in degrees for first reference point
-  private double       distance2   = 60;    // x position in inches for second reference point
-  private double       vertOffset2 = -4.85; // y reading in degrees for second reference point
-  private double       distLL;                // calculated distance in inches for the current y value
+  private double       m_distance1   = 48;    // x position in inches for first reference point
+  private double       m_vertOffset1 = 0.42;  // y reading in degrees for first reference point
+  private double       m_distance2   = 60;    // x position in inches for second reference point
+  private double       m_vertOffset2 = -4.85; // y reading in degrees for second reference point
+  private double       m_distLL;                // calculated distance in inches for the current y value
 
   // Creates a MedianFilter with a window size of 5 samples
-  MedianFilter         yfilter     = new MedianFilter(5); // filter y values to remove outliers
+  MedianFilter         m_yfilter     = new MedianFilter(5); // filter y values to remove outliers
 
   /**
    *
@@ -52,16 +52,16 @@ public class Vision extends SubsystemBase
 
     // Read these values from config file
     RobotConfig config = RobotConfig.getInstance( );
-    distance1 = config.getValueAsDouble("VI_distance1", 48.0);
-    distance2 = config.getValueAsDouble("VI_distance2", 60.0);
-    vertOffset1 = config.getValueAsDouble("VI_vertOffset1", 0.42);
-    vertOffset2 = config.getValueAsDouble("VI_vertOffset2", -4.85);
+    m_distance1 = config.getValueAsDouble("VI_distance1", 48.0);
+    m_distance2 = config.getValueAsDouble("VI_distance2", 60.0);
+    m_vertOffset1 = config.getValueAsDouble("VI_vertOffset1", 0.42);
+    m_vertOffset2 = config.getValueAsDouble("VI_vertOffset2", -4.85);
 
     // Put all the needed widgets on the dashboard
-    SmartDashboard.putNumber("VI_distance1", distance1);
-    SmartDashboard.putNumber("VI_distance2", distance2);
-    SmartDashboard.putNumber("VI_vertOffset1", vertOffset1);
-    SmartDashboard.putNumber("VI_vertOffset2", vertOffset2);
+    SmartDashboard.putNumber("VI_distance1", m_distance1);
+    SmartDashboard.putNumber("VI_distance2", m_distance2);
+    SmartDashboard.putNumber("VI_vertOffset1", m_vertOffset1);
+    SmartDashboard.putNumber("VI_vertOffset2", m_vertOffset2);
 
     SmartDashboard.setDefaultBoolean("VI_OVERRIDE", false);
     SmartDashboard.putNumber("VI_OVERRIDE_TX", 0.0);
@@ -80,30 +80,30 @@ public class Vision extends SubsystemBase
     if (SmartDashboard.getBoolean("VI_OVERRIDE", false))
     {
       // Allow the limelight to be bypassed by entries from the dashboard
-      targetHorizAngle = SmartDashboard.getNumber("VI_OVERRIDE_TX", 0.0);
-      targetVertAngle = SmartDashboard.getNumber("VI_OVERRIDE_TY", 0.0);
-      targetArea = SmartDashboard.getNumber("VI_OVERRIDE_TA", 0.0);
-      targetSkew = SmartDashboard.getNumber("VI_OVERRIDE_TS", 0.0);
-      targetValid = SmartDashboard.getBoolean("VI_OVERRIDE_TV", true);
+      m_targetHorizAngle = SmartDashboard.getNumber("VI_OVERRIDE_TX", 0.0);
+      m_targetVertAngle = SmartDashboard.getNumber("VI_OVERRIDE_TY", 0.0);
+      m_targetArea = SmartDashboard.getNumber("VI_OVERRIDE_TA", 0.0);
+      m_targetSkew = SmartDashboard.getNumber("VI_OVERRIDE_TS", 0.0);
+      m_targetValid = SmartDashboard.getBoolean("VI_OVERRIDE_TV", true);
     }
     else
     {
-      targetHorizAngle = table.getEntry("tx").getDouble(0.0);
-      targetVertAngle = yfilter.calculate(table.getEntry("ty").getDouble(0.0));
-      targetArea = table.getEntry("ta").getDouble(0.0);
-      targetSkew = table.getEntry("ts").getDouble(0.0);
-      targetValid = table.getEntry("tv").getBoolean(false);
+      m_targetHorizAngle = table.getEntry("tx").getDouble(0.0);
+      m_targetVertAngle = m_yfilter.calculate(table.getEntry("ty").getDouble(0.0));
+      m_targetArea = table.getEntry("ta").getDouble(0.0);
+      m_targetSkew = table.getEntry("ts").getDouble(0.0);
+      m_targetValid = table.getEntry("tv").getBoolean(false);
     }
 
-    distLL = calculateDist(targetVertAngle);
+    m_distLL = calculateDist(m_targetVertAngle);
 
-    SmartDashboard.putNumber("VI_horizAngle", targetHorizAngle);
-    SmartDashboard.putNumber("VI_vertAngle", targetVertAngle);
-    SmartDashboard.putNumber("VI_area", targetArea);
-    SmartDashboard.putNumber("VI_skew", targetSkew);
-    SmartDashboard.putBoolean("VI_valid", targetValid);
+    SmartDashboard.putNumber("VI_horizAngle", m_targetHorizAngle);
+    SmartDashboard.putNumber("VI_vertAngle", m_targetVertAngle);
+    SmartDashboard.putNumber("VI_area", m_targetArea);
+    SmartDashboard.putNumber("VI_skew", m_targetSkew);
+    SmartDashboard.putBoolean("VI_valid", m_targetValid);
 
-    SmartDashboard.putNumber("VI_distLL", distLL);
+    SmartDashboard.putNumber("VI_distLL", m_distLL);
   }
 
   @Override
@@ -126,32 +126,32 @@ public class Vision extends SubsystemBase
 
   public double getHorizOffsetDeg( )
   {
-    return targetHorizAngle;
+    return m_targetHorizAngle;
   }
 
   public double getVertOffsetDeg( )
   {
-    return targetVertAngle;
+    return m_targetVertAngle;
   }
 
   public double getTargetArea( )
   {
-    return targetArea;
+    return m_targetArea;
   }
 
   public double getTargetSkew( )
   {
-    return targetSkew;
+    return m_targetSkew;
   }
 
   public boolean getTargetValid( )
   {
-    return targetValid;
+    return m_targetValid;
   }
 
-  public double getgetDistLimelight( )
+  public double getDistLimelight( )
   {
-    return distLL;
+    return m_distLL;
   }
 
   public void setLEDMode(int mode)
@@ -180,19 +180,19 @@ public class Vision extends SubsystemBase
 
   private double calculateDist(double vertAngle)
   {
-    double slope = (distance2 - distance1) / (vertOffset2 - vertOffset1);
-    double offset = distance1 - slope * vertOffset1;
+    double slope = (m_distance2 - m_distance1) / (m_vertOffset2 - m_vertOffset1);
+    double offset = m_distance1 - slope * m_vertOffset1;
 
     SmartDashboard.putNumber("VI_Slope", slope);
 
     return (slope * vertAngle) + offset;
   }
 
-  private void syncStateFromDashboard( )
+  public void syncStateFromDashboard( )
   {
-    distance1 = SmartDashboard.getNumber("VI_distance1", distance1);
-    distance2 = SmartDashboard.getNumber("VI_distance2", distance2);
-    vertOffset1 = SmartDashboard.getNumber("VI_vertOffset1", vertOffset1);
-    vertOffset2 = SmartDashboard.getNumber("VI_vertOffset2", vertOffset2);
+    m_distance1 = SmartDashboard.getNumber("VI_distance1", m_distance1);
+    m_distance2 = SmartDashboard.getNumber("VI_distance2", m_distance2);
+    m_vertOffset1 = SmartDashboard.getNumber("VI_vertOffset1", m_vertOffset1);
+    m_vertOffset2 = SmartDashboard.getNumber("VI_vertOffset2", m_vertOffset2);
   }
 }


### PR DESCRIPTION
This builds and simulates successfully. I had to change some of the methods in Vision to be accessible in Drivetrain. I also renamed the variables in the class to match the new form of m_variablename. 

There were some errors in Drivetrain that about the std namespace. I wasn't sure how to call it or use it, so I just commented it out. There was also an error in defining and declaring a variable called output which was defined in a videodev2.h in Comp2022. 

To find these issues, do a Control F for TODO. 