### PR TITLE
Port simulateLimelight and add climberCalibrate

### DIFF
--- a/Offseason2022/src/main/java/frc/robot/Constants.java
+++ b/Offseason2022/src/main/java/frc/robot/Constants.java
@@ -158,10 +158,10 @@ public class Constants
     public static final double kFlywheelPidKd           = 0.025;
     public static final double kFlywheelNeutralDeadband = 0.004;
 
-    public static final double kFlywheelToleranceRPM    = 200.0;     // Tolerance band around target RPM
-    public static final double kFlywheelPrimeRPM        = 1000.0;    // RPM for priming the shooter
+    public static final double kFlywheelToleranceRPM    = 150.0;     // Tolerance band around target RPM
     public static final double kFlywheelLowerTargetRPM  = 1000.0;    // RPM for lower hub
-    public static final double kFlywheelUpperTargetRPM  = 2200.0;    // RPM for upper hub
+    public static final double kFlywheelUpperTargetRPM  = 2150.0;    // RPM for upper hub
+    public static final double kFlywheelPrimeRPM        = kFlywheelUpperTargetRPM; // RPM for priming the shooter
 
     public static final double kReverseRPMThreshold     = 20.0;      // RPM threshold for allowing reverse of motor
     public static final double kFlywheelReverseRPM      = -1000.0;   // RPM for reversing out game pieces

--- a/Offseason2022/src/main/java/frc/robot/Robot.java
+++ b/Offseason2022/src/main/java/frc/robot/Robot.java
@@ -160,6 +160,8 @@ public class Robot extends TimedRobot
     {
       m_autonomousCommand.cancel( );
     }
+
+    CommandScheduler.getInstance( ).schedule(m_robotContainer.m_climberCalibrate);
   }
 
   /**

--- a/Offseason2022/src/main/java/frc/robot/RobotContainer.java
+++ b/Offseason2022/src/main/java/frc/robot/RobotContainer.java
@@ -317,7 +317,7 @@ public class RobotContainer
     driverBack.whenPressed(new Dummy(XboxController.Button.kBack.value), true);
     driverStart.toggleWhenPressed(new VisionOn(m_vision, true), true);
 
-    // Operator - POV buttons
+    // Driver - POV buttons
     driverUp.whenPressed(new Dummy(0), true);
     driverRight.whenPressed(new Dummy(90), true);
     driverDown.whenPressed(new Dummy(180), true);

--- a/Offseason2022/src/main/java/frc/robot/RobotContainer.java
+++ b/Offseason2022/src/main/java/frc/robot/RobotContainer.java
@@ -324,10 +324,10 @@ public class RobotContainer
     driverLeft.whenPressed(new Dummy(270), true);
 
     // Driver - Triggers
-    driverLeftTrigger
+    driverRightTrigger
         .whenActive(new DriveLimelightShoot(m_drivetrain, m_intake, m_floorConveyor, m_towerConveyor, m_shooter, m_vision));
     driverRightTrigger
-        .whenActive(new DriveLimelightStop(m_drivetrain, m_intake, m_floorConveyor, m_towerConveyor, m_shooter, m_vision));
+        .whenInactive(new DriveLimelightStop(m_drivetrain, m_intake, m_floorConveyor, m_towerConveyor, m_shooter, m_vision));
 
     ///////////////////////////////////////////////////////
     // Operator Controller Assignments
@@ -361,8 +361,8 @@ public class RobotContainer
     operLeftBumper.whenPressed(new IntakingAction(m_intake, m_floorConveyor, m_towerConveyor), true);
     operLeftBumper.whenReleased(new IntakingStop(m_intake, m_floorConveyor, m_towerConveyor), true);
     operRightBumper.whenPressed(new ScoringPrime(m_shooter, m_vision), true);
-    operBack.toggleWhenPressed(new ClimberFullClimb(m_climber, m_operator, XboxController.Button.kY), true);
-    operStart.whenPressed(new ClimberRun(m_climber, m_operator), true);
+    operStart.toggleWhenPressed(new ClimberRun(m_climber, m_operator), true);
+    operBack.whenPressed(new ClimberFullClimb(m_climber, m_operator, XboxController.Button.kY), true);
 
     // Operator - POV buttons
     operUp.whenPressed(new Climber1Deploy(m_climber, m_intake, m_floorConveyor, m_towerConveyor, m_shooter, m_drivetrain), true);

--- a/Offseason2022/src/main/java/frc/robot/RobotContainer.java
+++ b/Offseason2022/src/main/java/frc/robot/RobotContainer.java
@@ -3,12 +3,17 @@
 
 package frc.robot;
 
+import edu.wpi.first.hal.HALUtil;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Axis;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.POVButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
@@ -115,6 +120,18 @@ public class RobotContainer
   // A chooser for autonomous commands
   SendableChooser<Command>      m_chooser        = new SendableChooser<>( );
 
+  private SimulateLimelight     m_simulateLimelightCommand =
+  // @formatter:off
+      new SimulateLimelight(m_drivetrain, 
+                            new Translation2d(Units.feetToMeters(54.0) / 2, Units.feetToMeters(27.0) / 2), // Field dimensions
+                            Units.inchesToMeters(102.81),                                                  // goal height
+                            new Translation2d(Units.inchesToMeters(0.0), Units.inchesToMeters(0.0)),       // camera translation on robot
+                            new Rotation2d(Units.degreesToRadians(0.0)),                                   // camera rotation on robot
+                            Units.inchesToMeters(41.0),                                                    // camera lens height
+                            Units.degreesToRadians(32.8));                                                 // camera back tilt
+  // @formatter:on
+  public Command                m_climberCalibrate         = new ClimberCalibrate(m_climber);
+
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
    */
@@ -215,8 +232,6 @@ public class RobotContainer
     SmartDashboard.putData("Shooter-REV", new ShooterRun(m_shooter, SHMode.SHOOTER_REVERSE));
     SmartDashboard.putData("ShooterReverse", new ShooterReverse(m_shooter));
 
-    SmartDashboard.putData("SimulateLimelight", new SimulateLimelight( ));
-
     SmartDashboard.putData("Tconveyor-STOP", new TowerConveyorRun(m_towerConveyor, TCMode.TCONVEYOR_STOP));
     SmartDashboard.putData("Tconveyor-ACQUIRE", new TowerConveyorRun(m_towerConveyor, TCMode.TCONVEYOR_ACQUIRE));
     SmartDashboard.putData("Tconveyor-ACQUIRESLOW", new TowerConveyorRun(m_towerConveyor, TCMode.TCONVEYOR_ACQUIRE_SLOW));
@@ -224,6 +239,9 @@ public class RobotContainer
     SmartDashboard.putData("Tconveyor-EXPELFAST", new TowerConveyorRun(m_towerConveyor, TCMode.TCONVEYOR_EXPEL_FAST));
 
     SmartDashboard.putData("Dummy", new Dummy(2135));
+
+    if (HALUtil.getHALRuntimeType( ) == HALUtil.RUNTIME_SIMULATION)
+      CommandScheduler.getInstance( ).schedule(m_simulateLimelightCommand);
   }
 
   private void initDefaultCommands( )

--- a/Offseason2022/src/main/java/frc/robot/commands/SimulateLimelight.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/SimulateLimelight.java
@@ -3,17 +3,54 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
+import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
+import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj.util.Color;
+import edu.wpi.first.wpilibj.util.Color8Bit;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.Drivetrain;
 
 /**
  *
  */
 public class SimulateLimelight extends CommandBase
 {
-  public SimulateLimelight( )
+  private final double LL2_HORIZ_HALF_FOV_DEG = 29.8;   // 59.6 degrees FOV
+  private final double LL2_VERT_HALF_FOV_DEG  = 24.85;  // 49.7 degrees FOV
+
+  Drivetrain           m_drivetrain;
+  Translation2d        m_goalTranslation;
+  double               m_goalHeightMeters;
+  Translation2d        m_cameraTranslationOffset;
+  Rotation2d           m_cameraYawOffset;
+  double               m_cameraHeightMeters;
+  double               m_cameraPitchRadians;
+
+  Mechanism2d          m_mech                 = new Mechanism2d(2.4, 2.0, new Color8Bit(Color.kBlack));
+  MechanismRoot2d      m_mechRoot             = m_mech.getRoot("Limelight", 0, 0);
+  MechanismLigament2d  m_mechLigament         =
+      m_mechRoot.append(new MechanismLigament2d("Target", 0.1, 0.0, 16, new Color8Bit(Color.kGreen)));
+
+  public SimulateLimelight(Drivetrain drivetrain, Translation2d goalTranslation, double goalHeightMeters,
+      Translation2d cameraTranslationOffset, Rotation2d cameraYawOffset, double cameraHeightMeters, double cameraPitchRadians)
   {
-    // m_subsystem = subsystem;
-    // addRequirements(m_subsystem);
+    m_drivetrain = drivetrain;
+    m_goalTranslation = goalTranslation;
+    m_goalHeightMeters = goalHeightMeters;
+    m_cameraTranslationOffset = cameraTranslationOffset;
+    m_cameraYawOffset = cameraYawOffset;
+    m_cameraHeightMeters = cameraHeightMeters;
+    m_cameraPitchRadians = cameraPitchRadians;
+
+    SmartDashboard.putData("Limelight (Sim)", m_mech);
   }
 
   // Called when the command is initially scheduled.
@@ -24,7 +61,28 @@ public class SimulateLimelight extends CommandBase
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute( )
-  {}
+  {
+    Pose2d robotPose = m_drivetrain.getPose( );
+    // The camera may not be centered on the robot, so we need to account for offets
+    Pose2d cameraPose = new Pose2d(robotPose.getTranslation( ).plus(m_cameraTranslationOffset.rotateBy(robotPose.getRotation( ))),
+        robotPose.getRotation( ).plus(m_cameraYawOffset));
+
+    // Get the goal translation and height as if the camera were at [0, 0, 0]
+    Translation2d cameraRelativeGoalTranslation =
+        (m_goalTranslation.minus(cameraPose.getTranslation( )).rotateBy(cameraPose.getRotation( ).unaryMinus( )));
+    double cameraRelativeGoalHeightMeters = m_goalHeightMeters - m_cameraHeightMeters;
+
+    double tx = Units.radiansToDegrees(-Math.atan2(cameraRelativeGoalTranslation.getY( ), cameraRelativeGoalTranslation.getX( )));
+    double ty = Units.radiansToDegrees(
+        Math.atan2(cameraRelativeGoalHeightMeters, cameraRelativeGoalTranslation.getNorm( )) - m_cameraPitchRadians);
+
+    NetworkTable table = NetworkTableInstance.getDefault( ).getTable("limelight");
+    table.getEntry("tx").setValue(tx);
+    table.getEntry("ty").setValue(ty);
+    table.getEntry("tv").setBoolean((tx >= -LL2_HORIZ_HALF_FOV_DEG && tx <= LL2_HORIZ_HALF_FOV_DEG)
+        && (ty >= -LL2_VERT_HALF_FOV_DEG && ty <= LL2_VERT_HALF_FOV_DEG));
+    m_mechRoot.setPosition(tx / LL2_HORIZ_HALF_FOV_DEG + (1.2 - 0.05), ty / LL2_VERT_HALF_FOV_DEG + 1);
+  }
 
   // Called once the command ends or is interrupted.
   @Override
@@ -41,6 +99,6 @@ public class SimulateLimelight extends CommandBase
   @Override
   public boolean runsWhenDisabled( )
   {
-    return false;
+    return true;
   }
 }

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -551,7 +551,7 @@ public class Drivetrain extends SubsystemBase
     m_odometry.resetPosition(pose, Rotation2d.fromDegrees(0.0));
   }
 
-  private Pose2d getPose( )
+  public Pose2d getPose( )
   {
     return m_odometry.getPoseMeters( );
   }
@@ -663,8 +663,10 @@ public class Drivetrain extends SubsystemBase
   public void driveWithJoysticksInit( )
   {
     setBrakeMode(true);
-    m_driveL1.configOpenloopRamp(m_openLoopRamp);
-    m_driveR3.configOpenloopRamp(m_openLoopRamp);
+    if (m_validL1)
+      m_driveL1.configOpenloopRamp(m_openLoopRamp);
+    if (m_validR3)
+      m_driveR3.configOpenloopRamp(m_openLoopRamp);
   }
 
   public void driveWithJoysticksExecute(XboxController driverPad)
@@ -707,8 +709,10 @@ public class Drivetrain extends SubsystemBase
   public void driveWithJoysticksEnd( )
   {
     setBrakeMode(false);
-    m_driveL1.configOpenloopRamp(0.0);
-    m_driveR3.configOpenloopRamp(0.0);
+    if (m_validL1)
+      m_driveL1.configOpenloopRamp(0.0);
+    if (m_validR3)
+      m_driveR3.configOpenloopRamp(0.0);
   }
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -739,6 +743,12 @@ public class Drivetrain extends SubsystemBase
     // load in Pid constants to controller
     m_turnPid = new PIDController(m_turnPidKp, m_turnPidKi, m_turnPidKd);
     m_throttlePid = new PIDController(m_throttlePidKp, m_throttlePidKi, m_throttlePidKd);
+
+    // TODO: Add this to eliminate robot lurch
+    // if (m_validL1)
+    // m_driveL1.configOpenloopRamp(m_openLoopRamp);
+    // if (m_validR3)
+    // m_driveR3.configOpenloopRamp(m_openLoopRamp);
 
     RobotContainer rc = RobotContainer.getInstance( );
     rc.m_vision.m_yfilter.reset( );
@@ -836,6 +846,12 @@ public class Drivetrain extends SubsystemBase
   {
     if (m_validL1 || m_validR3)
       velocityArcadeDrive(0.0, 0.0);
+
+    // TODO: return settings back when command ends
+    // if (m_validL1)
+    // m_driveL1.configOpenloopRamp(0.0);
+    // if (m_validR3)
+    // m_driveR3.configOpenloopRamp(0.0);
 
     RobotContainer.getInstance( ).m_led.setLLColor(LEDColor.LEDCOLOR_OFF);
   }

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Vision.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Vision.java
@@ -24,7 +24,7 @@ public class Vision extends SubsystemBase
   private double       m_distance2   = VIConsts.kLLDistance2;   // x position in inches for second reference point
   private double       m_vertOffset2 = VIConsts.kLLVertOffset2; // y reading in degrees for second reference point
 
-  private NetworkTable table;              // Network table reference for getting LL values
+  private NetworkTable m_table;            // Network table reference for getting LL values
 
   private double       m_targetHorizAngle; // LL Target horizontal Offset from Crosshair to Target (-27 to 27 deg)
   private double       m_targetVertAngle;  // LL Target vertical Offset from Crosshair to Target (-20.5 to 20.5 deg)
@@ -43,7 +43,7 @@ public class Vision extends SubsystemBase
     setSubsystem("Vision");
 
     // Get the Network table reference once for all methods
-    table = NetworkTableInstance.getDefault( ).getTable("limelight");
+    m_table = NetworkTableInstance.getDefault( ).getTable("limelight");
 
     // Set camera and LED display
     setLEDMode(VIConsts.LED_ON);
@@ -79,11 +79,11 @@ public class Vision extends SubsystemBase
     }
     else
     {
-      m_targetHorizAngle = table.getEntry("tx").getDouble(0.0);
-      m_targetVertAngle = m_yfilter.calculate(table.getEntry("ty").getDouble(0.0));
-      m_targetArea = table.getEntry("ta").getDouble(0.0);
-      m_targetSkew = table.getEntry("ts").getDouble(0.0);
-      m_targetValid = table.getEntry("tv").getBoolean(false);
+      m_targetHorizAngle = m_table.getEntry("tx").getDouble(0.0);
+      m_targetVertAngle = m_yfilter.calculate(m_table.getEntry("ty").getDouble(0.0));
+      m_targetArea = m_table.getEntry("ta").getDouble(0.0);
+      m_targetSkew = m_table.getEntry("ts").getDouble(0.0);
+      m_targetValid = m_table.getEntry("tv").getBoolean(false);
     }
 
     m_distLL = calculateDist(m_targetVertAngle);
@@ -148,12 +148,12 @@ public class Vision extends SubsystemBase
   public void setLEDMode(int mode)
   {
     DataLogManager.log(getSubsystem( ) + ": setLedMode " + mode);
-    table.getEntry("ledMode").setValue(mode);
+    m_table.getEntry("ledMode").setValue(mode);
   }
 
   public int getLEDMode( )
   {
-    int mode = (int) table.getEntry("ledMode").getNumber(0.0);
+    int mode = (int) m_table.getEntry("ledMode").getNumber(0.0);
 
     DataLogManager.log(getSubsystem( ) + "getLedMode :" + mode);
     return mode;
@@ -162,7 +162,7 @@ public class Vision extends SubsystemBase
   public void setCameraDisplay(int stream)
   {
     DataLogManager.log(getSubsystem( ) + ": setCameraDisplay " + stream);
-    table.getEntry("stream").setValue(stream);
+    m_table.getEntry("stream").setValue(stream);
   }
 
   private double calculateDist(double vertAngle)


### PR DESCRIPTION
Ported simulateLimelight command from C++, added initial climberCalibrate command when entering Teleop to match C++ operation, tightened shooter RPM tolerance from +/- 200RPM to +/-150RPM, changed shooter priming speed from lowerhub value to upperhub value. These were leftover tuning that we had from spring.