### PR TITLE
Added PrintCommands to climber movements for easier debugging

### DIFF
--- a/Offseason2022/src/main/java/frc/robot/commands/Climber0Stow.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/Climber0Stow.java
@@ -4,6 +4,7 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
@@ -33,6 +34,7 @@ public class Climber0Stow extends SequentialCommandGroup
         // Add Commands here:
 
         // @formatter:off
+        new PrintCommand("Climber --- Stow climber, reset all other subsystems ---"),
         new DriveSlowMode(drivetrain, false), 
         new IntakeDeploy(intake, false), 
         new IntakeRun(intake, INMode.INTAKE_STOP),
@@ -43,6 +45,8 @@ public class Climber0Stow extends SequentialCommandGroup
             new WaitUntilCommand(climber::moveClimberDistanceIsFinished),
             new ClimberMoveToHeight(climber, CLHeight.HEIGHT_STOW)
         ),
+
+        new PrintCommand("Climber --- Relax climber to rest position ---"),
         new WaitCommand(1.5), 
         new ParallelDeadlineGroup(
             new WaitUntilCommand(climber::moveClimberDistanceIsFinished),

--- a/Offseason2022/src/main/java/frc/robot/commands/Climber1Deploy.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/Climber1Deploy.java
@@ -4,6 +4,7 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 import frc.robot.Constants.CLConsts.CLHeight;
@@ -32,6 +33,7 @@ public class Climber1Deploy extends SequentialCommandGroup
         // Add Commands here:
 
         // @formatter:off
+        new PrintCommand("Climber --- Deploy climber, reset all other subsystems ---"),
         new DriveSlowMode(drivetrain, true), 
         new IntakeDeploy(intake, false), 
         new IntakeRun(intake, INMode.INTAKE_STOP),

--- a/Offseason2022/src/main/java/frc/robot/commands/ClimberFullClimb.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/ClimberFullClimb.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.Constants.CLConsts;
@@ -37,21 +38,28 @@ public class ClimberFullClimb extends SequentialCommandGroup
         // Add Commands here:
 
         // @formatter:off
+        new PrintCommand("Climber --- Pull up to Mid rung and engage gate hook ---"),
         new Climber2ClimbToL2(climber),
         new ParallelRaceGroup(
             new WaitCommand(m_climbL2Time), 
             new ClimberTimerOverride(climber, gamePad, button)
         ),
+
+        new PrintCommand("Climber --- Extend and rotate toward High rung ---"),
         new Climber3RotateToL3(climber),
         new ParallelRaceGroup(
             new WaitCommand(m_rotateExtendL3Time), 
             new ClimberTimerOverride(climber, gamePad, button)
         ),
+
+        new PrintCommand("Climber --- Pull gatehook into High rung ---"),
         new Climber5RotateIntoL3(climber),
         new ParallelRaceGroup(
             new WaitCommand(m_rotateRetractL3Time), 
             new ClimberTimerOverride(climber, gamePad, button)
         ),
+
+        new PrintCommand("Climber --- Pull robot up to L3 ---"),
         new Climber6ClimbToL3(climber),
         new ParallelRaceGroup(
             new WaitCommand(m_climbL3Time), 
@@ -59,16 +67,21 @@ public class ClimberFullClimb extends SequentialCommandGroup
         ),
 
         // next rung climb!
+        new PrintCommand("Climber --- Extend and rotate toward Traversal rung ---"),
         new Climber3RotateToL3(climber),
         new ParallelRaceGroup(
             new WaitCommand(m_rotateExtendL3Time), 
             new ClimberTimerOverride(climber, gamePad, button)
         ),
+
+        new PrintCommand("Climber --- Pull gatehook into Traversal rung ---"),
         new Climber5RotateIntoL3(climber),
         new ParallelRaceGroup(
             new WaitCommand(m_rotateRetractL4Time), 
             new ClimberTimerOverride(climber, gamePad, button)
         ),
+
+        new PrintCommand("Climber --- Pull robot up to Traversal rung ---"),
         new Climber7ClimbToL4(climber)
         // @formatter:on 
     );

--- a/Offseason2022/src/main/java/frc/robot/commands/ClimberL2ToL3.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/ClimberL2ToL3.java
@@ -3,6 +3,7 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.Constants.CLConsts;
@@ -30,12 +31,19 @@ public class ClimberL2ToL3 extends SequentialCommandGroup
         // Add Commands here:
 
         // @formatter:off
+        new PrintCommand("Climber --- Pull up to Mid rung and engage gate hook ---"),
         new Climber2ClimbToL2(climber),
         new WaitCommand(m_climbL2Time), // check to see if timer is necessary here
+
+        new PrintCommand("Climber --- Extend and rotate toward High rung ---"),
         new Climber3RotateToL3(climber),
         new WaitCommand(m_rotateExtendL3Time),
+
+        new PrintCommand("Climber --- Pull gatehook into High rung ---"),
         new Climber5RotateIntoL3(climber),
         new WaitCommand(m_rotateRetractL3Time),
+
+        new PrintCommand("Climber --- Pull robot up to L3 ---"),
         new Climber6ClimbToL3(climber),
         new WaitCommand(m_climbL3Time) 
         // @formatter:on

--- a/Offseason2022/src/main/java/frc/robot/commands/ClimberL3ToL4.java
+++ b/Offseason2022/src/main/java/frc/robot/commands/ClimberL3ToL4.java
@@ -3,6 +3,7 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.Constants.CLConsts;
@@ -28,10 +29,15 @@ public class ClimberL3ToL4 extends SequentialCommandGroup
         // Add Commands here:
 
         // @formatter:off
+        new PrintCommand("Climber --- Extend and rotate toward Traversal rung ---"),
         new Climber3RotateToL3(climber),
         new WaitCommand(m_rotateExtendL3Time),
+
+        new PrintCommand("Climber --- Pull gatehook into Traversal rung ---"),
         new Climber5RotateIntoL3(climber),
         new WaitCommand(m_rotateRetractL4Time),
+
+        new PrintCommand("Climber --- Pull robot up to Traversal rung ---"),
         new Climber7ClimbToL4(climber)
         // @formatter:on
     );

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Climber.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Climber.java
@@ -247,7 +247,7 @@ public class Climber extends SubsystemBase
 
     m_curInches = countsToInches((int) curCounts);
     m_targetInches = m_curInches;
-    DataLogManager.log(getSubsystem( ) + ": Init Target Inches: " + m_targetInches);
+    DataLogManager.log(getSubsystem() + ": Init Target Inches: " + String.format("%.1f", m_targetInches));
   }
 
   // Dump all Talon faults
@@ -480,13 +480,15 @@ public class Climber extends SubsystemBase
       // Height constraint check/soft limit for max and min height before raising
       if (m_targetInches < m_climberMinHeight)
       {
-        DataLogManager.log("Target " + m_targetInches + " inches is limited by " + m_climberMinHeight + " inches");
+        DataLogManager.log("Target " + String.format("%.1f", m_targetInches) + " inches is limited by "
+            + String.format("%.1f", m_climberMinHeight) + " inches");
         m_targetInches = m_climberMinHeight;
       }
 
       if (m_targetInches > m_climberMaxHeight)
       {
-        DataLogManager.log("Target " + m_targetInches + " inches is limited by " + m_climberMaxHeight + " inches");
+        DataLogManager.log("Target " + String.format("%.1f", m_targetInches) + " inches is limited by "
+            + String.format("%.1f", m_climberMaxHeight) + " inches");
         m_targetInches = m_climberMaxHeight;
       }
 
@@ -498,7 +500,8 @@ public class Climber extends SubsystemBase
       m_motorCL14.set(ControlMode.MotionMagic, inchesToCounts(m_targetInches));
       m_motorCL15.set(ControlMode.MotionMagic, inchesToCounts(m_targetInches));
 
-      DataLogManager.log("Climber moving: " + m_curInches + " -> " + m_targetInches + " inches  |  counts "
+      DataLogManager.log("Climber moving: " + String.format("%.1f", m_curInches) + " -> "
+          + String.format("%.1f", m_targetInches) + " inches  |  counts "
           + inchesToCounts(m_curInches) + " -> " + inchesToCounts(m_targetInches));
     }
     else
@@ -524,7 +527,8 @@ public class Climber extends SubsystemBase
       if (++m_withinTolerance >= 5)
       {
         isFinished = true;
-        DataLogManager.log("Climber move finished - Time: " + m_safetyTimer.get( ) + "  |  Cur inches: " + m_curInches);
+        DataLogManager.log("Climber move finished - Time: " + String.format("%.3f", m_safetyTimer.get())
+            + "  |  Cur inches: " + String.format("%.1f", m_curInches));
       }
     }
     else

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -917,12 +917,12 @@ public class Drivetrain extends SubsystemBase
       {
         Trajectory.State curState = trajStates.get(i);
         DataLogManager.log(getSubsystem( )
-            // formmater:off
+            // @formatter:off
             + ": DTR state time: " + String.format("%.3f", curState.timeSeconds)                      //
-            + " Vel: " + String.format("%.2f", curState.velocityMetersPerSecond)                      //
-            + " Accel: " + String.format("%.2f", curState.accelerationMetersPerSecondSq)              //
-            + " Rotation: " + String.format("%.1f", curState.poseMeters.getRotation( ).getDegrees( )) //
-        // formatter:on
+            + " Vel: "             + String.format("%.2f", curState.velocityMetersPerSecond)                      //
+            + " Accel: "           + String.format("%.2f", curState.accelerationMetersPerSecondSq)              //
+            + " Rotation: "        + String.format("%.1f", curState.poseMeters.getRotation( ).getDegrees( )) //
+        // @formatter:on
         );
       }
 

--- a/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/Offseason2022/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -918,10 +918,10 @@ public class Drivetrain extends SubsystemBase
         Trajectory.State curState = trajStates.get(i);
         DataLogManager.log(getSubsystem( )
             // @formatter:off
-            + ": DTR state time: " + String.format("%.3f", curState.timeSeconds)                      //
-            + " Vel: "             + String.format("%.2f", curState.velocityMetersPerSecond)                      //
-            + " Accel: "           + String.format("%.2f", curState.accelerationMetersPerSecondSq)              //
-            + " Rotation: "        + String.format("%.1f", curState.poseMeters.getRotation( ).getDegrees( )) //
+            + ": DTR state time: " + String.format("%.3f", curState.timeSeconds)
+            + " Vel: "             + String.format("%.2f", curState.velocityMetersPerSecond)
+            + " Accel: "           + String.format("%.2f", curState.accelerationMetersPerSecondSq)
+            + " Rotation: "        + String.format("%.1f", curState.poseMeters.getRotation( ).getDegrees( ))
         // @formatter:on
         );
       }


### PR DESCRIPTION
Should help with debugging climber timing and understanding movements. Also reduced displayed digits for movements and times instead of defaulting to 10-12 decimal places.